### PR TITLE
Update PeTrack link to new documentation

### DIFF
--- a/content/open_source_software/_index.md
+++ b/content/open_source_software/_index.md
@@ -15,7 +15,7 @@ on our
   {{< card link="https://pedpy.readthedocs.io" image="pedpy.svg" title="PedPy" icon="terminal" subtitle="A Python module to analyze real and simulated pedestrian trajectories.">}}
   {{< card link="https://jupedsim.org" title="JuPedSim" image="jupedsim.svg" icon="terminal" subtitle="A Python module to simulate pedestrian dynamics.">}}
   {{< card link="https://www.vadere.org" title="VADERE" image="vadere.svg" icon="terminal" subtitle="A Java framework for the simulation of microscopic pedestrian and crowd dynamics.">}}
-{{< card link="https://jugit.fz-juelich.de/ped-dyn-emp/petrack/-/wikis/home" title="PeTrack" image="petrack.png" icon="terminal" subtitle="Automatic Extraction of Pedestrian Trajectories from Video Recordings.">}}
+{{< card link="https://go.fzj.de/petrack-docs" title="PeTrack" image="petrack.png" icon="terminal" subtitle="Automatic Extraction of Pedestrian Trajectories from Video Recordings.">}}
 {{< card link="https://project.inria.fr/crowdscience/project/ocsr/umans/" title="UMANS" image="UMANS.svg"  icon="terminal" subtitle="C++ crowd-simulation framework for experimentation and for honest comparisons between algorithms." >}}
 {{< card link="http://www.cromosim.fr" title="CROMOSIM" image="cromosim.png"  icon="terminal" subtitle="A Python Library for microscopic Crowd Motion Simulation." >}}
 {{< card link="https://datafold-dev.gitlab.io/datafold/" image="datafold_logo_pre.svg" title="datafold" icon="terminal" subtitle="Learn operator-theoretic models for dynamical systems from time series data." >}}


### PR DESCRIPTION
PeTrack shifted away from the GitLab Wiki in support of ReadTheDocs. I updated the link accordingly. (I did not test the website build locally, but assume such a local change won't be a problem)